### PR TITLE
Change quay.io/k8scsi/livenessprobe to registry.k8s.io/sig-storage/livenessprobe

### DIFF
--- a/chart/templates/06-controller.yaml
+++ b/chart/templates/06-controller.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         # Liveness-probe
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v1.1.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/chart/templates/07-nodes.yaml
+++ b/chart/templates/07-nodes.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         # Liveness probe
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v1.1.0
           imagePullPolicy: Always
           args:
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
Old image link was giving this error:
> Failed to pull image "quay.io/k8scsi/livenessprobe:v1.1.0": failed to pull and unpack image "quay.io/k8scsi/livenessprobe:v1.1.0": failed to get conve
rter for "quay.io/k8scsi/livenessprobe:v1.1.0": Pulling Schema 1 images have been deprecated and disabled by default since containerd v2.0. As a workaround you may set an environment variable `CONTAINERD_ENABLE_D
EPRECATED_PULL_SCHEMA_1_IMAGE=1`, but this will be completely removed in containerd v2.1

See https://github.com/kubernetes-csi/livenessprobe